### PR TITLE
[SSSF-18] Применение LEFT JOIN для вложенных сущностей в динамических фильтрах

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>ru.standard-solutions</groupId>
     <artifactId>spring-fetch</artifactId>
-    <version>0.2.4</version>
+    <version>0.2.5</version>
     <name>spring-fetch</name>
     <description>Fetching API for generating spring boot database queries</description>
     <url>standard-solutions.ru</url>

--- a/src/main/java/ru/standardsolutions/Operator.java
+++ b/src/main/java/ru/standardsolutions/Operator.java
@@ -179,8 +179,12 @@ public enum Operator {
     private static Path<?> getFieldPath(Root<?> root, String fieldName) {
         String[] parts = fieldName.split("\\.");
         Path<?> path = root;
-        for (String part : parts) {
-            path = path.get(part);
+        for (int i = 0; i < parts.length; i++) {
+            if (i == 0 && parts.length > 1) {
+                path = root.join(parts[i], JoinType.LEFT);
+            } else {
+                path = path.get(parts[i]);
+            }
         }
         return path;
     }


### PR DESCRIPTION
Реализовано применение LEFT JOIN для вложенных полей, чтобы избежать потери записей без связей при фильтрации.